### PR TITLE
Connect peers on every iteration

### DIFF
--- a/spec/flying_shuttle/peer_service_spec.rb
+++ b/spec/flying_shuttle/peer_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe FlyingShuttle::PeerService do
       expect(weave_client).to receive(:post).with(
         hash_including(
           path: '/connect',
-          body: 'peer[]=a&peer[]=b&replace=true'
+          body: 'peer=a&peer=b&replace=true'
         )
       ).and_return(response)
       expect(subject.set_peers(peers)).to be_truthy
@@ -66,11 +66,11 @@ RSpec.describe FlyingShuttle::PeerService do
 
     it 'returns false if peers cannot be set' do
       peers = ['a', 'b']
-      response = double(:response, status: 400)
+      response = double(:response, status: 400, body: '')
       expect(weave_client).to receive(:post).with(
         hash_including(
           path: '/connect',
-          body: 'peer[]=a&peer[]=b&replace=true'
+          body: 'peer=a&peer=b&replace=true'
         )
       ).and_return(response)
       expect(subject.set_peers(peers)).to be_falsey


### PR DESCRIPTION
Otherwise peer might end up in a state where all peers have been dropped (network issues etc). This is brute-force fix but should work quite well. More sophisticated implementation would query existing peers/targets and connect only if something does not match.